### PR TITLE
jail: create: pkg: fix install by installing generic flavor

### DIFF
--- a/src/share/poudriere/jail.sh
+++ b/src/share/poudriere/jail.sh
@@ -711,7 +711,7 @@ install_from_pkg() {
 	REMOTEVER=$(pkg rquery "%At=%Av" ports-mgmt/pkg | grep "FreeBSD_version" | cut -d '=' -f 2 | cut -c 1-2)
 	ABISTRING="FreeBSD:${REMOTEVER}:${ARCH}"
 
-	INSLIST="os/userland os/src os/kernel os/buildworld os/buildkernel"
+	INSLIST="os-generic-userland os/src os-generic-kernel os-generic-buildworld os-generic-buildkernel"
 
 	# Make pkg play nice
 	export IGNORE_OSVERSION="YES"


### PR DESCRIPTION
poudriere jail -c -m pkg= fails to install from a repository with
flavors since it tries to install all of the flavors. This fixes it by
just installing generic for now.